### PR TITLE
Change Base64 for HEX encoding to survive URL encoding done by various API's

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"context"
 	"crypto/rand"
-	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -28,7 +28,7 @@ func (s *Scopes) Set(value string) error {
 func randString() string {
 	buf := make([]byte, 32)
 	rand.Read(buf)
-	return base64.StdEncoding.EncodeToString(buf)
+	return hex.EncodeToString(buf)
 }
 
 func main() {


### PR DESCRIPTION
Hi. Ran into the situation where a Base64 URL encoded state passed to an authorisation endpoint (e.g Netatmo's API) came back partly decoded i.e `%2B` came back as `+` - which is part of the standard Base64 charset. This is further decoded when comparing the initial state with the passed back state so `+` becomes ` ` (space, i.e `%20`, `+` is an alternative way to URL encode space) which then fails the comparison and `oauth2-cli` fails with an invalid state error.

This PR changes the Base64 encoding for HEX encoding which is better suited to survive across URL's passed back and forth and silly things done by some service API's. Since this is basically a random string, the encoding doesn't really matter than much for as long as it doesn't cause issues.